### PR TITLE
Add error handling when value of time is empty.

### DIFF
--- a/private/protocol/xml/xmlutil/unmarshal.go
+++ b/private/protocol/xml/xmlutil/unmarshal.go
@@ -268,11 +268,15 @@ func parseScalar(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
 		}
 		r.Set(reflect.ValueOf(v))
 	case time.Time:
-		t, err := time.Parse(time.RFC3339, node.Text)
-		if err != nil {
-			return err
+		if len(node.Text) == 0 {
+			r.Set(reflect.ValueOf(node.Text))
+		} else {
+			t, err := time.Parse(time.RFC3339, node.Text)
+			if err != nil {
+				return err
+			}
+			r.Set(reflect.ValueOf(t))
 		}
-		r.Set(reflect.ValueOf(t))
 	default:
 		return fmt.Errorf("unsupported value: %v (%s)", r.Interface(), r.Type())
 	}

--- a/private/protocol/xml/xmlutil/unmarshal.go
+++ b/private/protocol/xml/xmlutil/unmarshal.go
@@ -268,9 +268,7 @@ func parseScalar(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
 		}
 		r.Set(reflect.ValueOf(v))
 	case time.Time:
-		if len(node.Text) == 0 {
-			r.Set(reflect.ValueOf(node.Text))
-		} else {
+		if len(node.Text) != 0 {
 			t, err := time.Parse(time.RFC3339, node.Text)
 			if err != nil {
 				return err


### PR DESCRIPTION
# Summary

- Add error handling when value of time is empty.

# Problem to be solved.

- An error occurs when the string that should contain time is empty.