### PR TITLE
Add Description field to VolumeSetItem

### DIFF
--- a/models/apis/computing/2016-11-15/api-2.json
+++ b/models/apis/computing/2016-11-15/api-2.json
@@ -17634,6 +17634,10 @@
           "locationName": "createTime",
           "shape": "TStamp"
         },
+        "Description": {
+          "locationName": "description",
+          "shape": "String"
+        },
         "DiskType": {
           "locationName": "diskType",
           "shape": "String"

--- a/service/computing/api.go
+++ b/service/computing/api.go
@@ -25565,6 +25565,8 @@ type VolumeSetItem struct {
 
 	CreateTime *time.Time `locationName:"createTime" type:"timestamp" timestampFormat:""`
 
+	Description *string `locationName:"description" type:"string"`
+
 	DiskType *string `locationName:"diskType" type:"string"`
 
 	NextMonthAccountingType *string `locationName:"nextMonthAccountingType" type:"string"`


### PR DESCRIPTION
# Summary

* Add Description field to VolumeSetItem because DescribeVolumes API response has it, but there is no definition in the json file.