### PR TITLE
Fix/auto fork script bug

### DIFF
--- a/hack/update_third_party.sh
+++ b/hack/update_third_party.sh
@@ -23,7 +23,7 @@ update_third_party::aws_sdk_go_v2::internal::awsutil() {
     PAGE_URL="https://github.com/aws/aws-sdk-go-v2/tree/${VERSION}/internal/awsutil/prettify.go"
     OUTPUT="${PROJECT_DIR}/internal/nifcloudutil/prettify.go"
     fork_from_aws_sdk_go_v2 ${DOWNLOAD_URL} ${PAGE_URL} ${OUTPUT}
-    sed -i "" -e s/package\sawsutil/package\snifcloudutil/g ${OUTPUT}
+    sed -i "" -e "s/package awsutil/package nifcloudutil/g" ${OUTPUT}
 }
 
 update_third_party::aws_sdk_go_v2::aws::endpoints() {

--- a/internal/nifcloudutil/prettify.go
+++ b/internal/nifcloudutil/prettify.go
@@ -1,7 +1,7 @@
 // This code was forked from github.com/aws/aws-sdk-go-v2. DO NOT EDIT.
 // URL: https://github.com/aws/aws-sdk-go-v2/tree/v0.15.0/internal/awsutil/prettify.go
 
-package awsutil
+package nifcloudutil
 
 import (
 	"bytes"


### PR DESCRIPTION
# Summary

Auto fork script does not replace original package name. (awsutil -> nifcloudutil)
This is caused by invalid sed regexp syntax in shell script.