### PR TITLE
Fix import bug: add aws and delete nifcloud

### DIFF
--- a/private/model/cli/mod-api/main.go
+++ b/private/model/cli/mod-api/main.go
@@ -123,7 +123,7 @@ func rewriteServiceFile(path string) error {
 func rewriteInterfaceFile(path string) error {
 	serviceName := filepath.Base(filepath.Dir(filepath.Dir(path)))
 	imports := []map[string]string{
-		{"github.com/aws/aws-sdk-go-v2/aws": "github.com/aokumasan/nifcloud-sdk-go-v2/nifcloud"},
+		{"github.com/aokumasan/nifcloud-sdk-go-v2/nifcloud": "github.com/aws/aws-sdk-go-v2/aws"},
 		{fmt.Sprintf("github.com/aws/aws-sdk-go-v2/service/%s", serviceName): fmt.Sprintf("github.com/aokumasan/nifcloud-sdk-go-v2/service/%s", serviceName)},
 	}
 

--- a/service/computing/computingiface/interface.go
+++ b/service/computing/computingiface/interface.go
@@ -11,7 +11,7 @@ package computingiface
 import (
 	"context"
 
-	"github.com/aokumasan/nifcloud-sdk-go-v2/nifcloud"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aokumasan/nifcloud-sdk-go-v2/service/computing"
 )
 


### PR DESCRIPTION
# issue
* `computing/computingiface`をインポートすると`go vet`で以下のようなエラーが発生

```
../../go/pkg/mod/github.com/aokumasan/nifcloud-sdk-go-v2@v0.0.5/service/computing/computingiface/interface.go:14:2: imported and not used: "github.com/aokumasan/nifcloud-sdk-go-v2/nifcloud"
../../go/pkg/mod/github.com/aokumasan/nifcloud-sdk-go-v2@v0.0.5/service/computing/computingiface/interface.go:487:82: undefined: aws
../../go/pkg/mod/github.com/aokumasan/nifcloud-sdk-go-v2@v0.0.5/service/computing/computingiface/interface.go:489:81: undefined: aws
../../go/pkg/mod/github.com/aokumasan/nifcloud-sdk-go-v2@v0.0.5/service/computing/computingiface/interface.go:491:82: undefined: aws
../../go/pkg/mod/github.com/aokumasan/nifcloud-sdk-go-v2@v0.0.5/service/computing/computingiface/interface.go:493:82: undefined: aws
```

# 変更内容
* `service/computing/computingiface/interface.go`を生成するスクリプトを変更
* `go run private/model/cli/mod-apimain.go --path service/computing/computingiface/interface.go`を実行